### PR TITLE
allow symfony 7 without deprecations

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,6 @@ jobs:
                     - "8.1"
                     - "8.2"
                     - "8.3"
-                    - "8.4"
                 operating-system:
                     - "ubuntu-latest"
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,25 +4,22 @@ on: ["pull_request", "push"]
 
 jobs:
     unit-tests:
-        name: "unit tests"
+        name: "unit tests ${{ matrix.php-version }} ${{ matrix.dependencies }}"
 
-        runs-on: ${{ matrix.operating-system }}
+        runs-on: ubuntu-latest
 
         strategy:
+            fail-fast: false
             matrix:
-                dependencies:
-                    - "lowest"
-                    - "highest"
                 php-version:
-                    - "7.2"
-                    - "7.3"
-                    - "7.4"
-                    - "8.0"
                     - "8.1"
                     - "8.2"
                     - "8.3"
-                operating-system:
-                    - "ubuntu-latest"
+                    - "8.4"
+                dependencies: ["highest"]
+                include:
+                  - php-version: "8.4"
+                    dependencies: "lowest"
 
         steps:
             - name: "checkout"
@@ -35,25 +32,10 @@ jobs:
                   ini-values: memory_limit=-1
                   tools: composer:v2, cs2pr
 
-            - name: "caching dependencies"
-              uses: "actions/cache@v2"
-              with:
-                  path: |
-                      ~/.composer/cache
-                      vendor
-                  key: "php-${{ matrix.php-version }}-${{ matrix.operating-system }}"
-                  restore-keys: "php-${{ matrix.php-version }}-${{ matrix.operating-system }}"
-
-            - name: "installing lowest dependencies"
-              if: ${{ matrix.dependencies == 'lowest' }}
-              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
-
-            - name: "installing highest dependencies"
-              if: ${{ matrix.dependencies == 'highest' }}
-              run: "composer update --no-interaction --no-progress --no-suggest"
-
-            - name: "installing phpunit"
-              run: "php vendor/bin/simple-phpunit install"
+            - name: "installing dependencies"
+              run: "composer update --no-interaction --no-progress --no-suggest ${{ matrix.dependencies == 'lowest' && '--prefer-lowest' || '' }}"
 
             - name: "running unit tests"
+              env:
+                SYMFONY_DEPRECATIONS_HELPER: ${{ matrix.php-version == '8.4' && 'disabled=1' || '' }}
               run: "php vendor/bin/simple-phpunit"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,16 @@ jobs:
                     - "7.3"
                     - "7.4"
                     - "8.0"
+                    - "8.1"
+                    - "8.2"
+                    - "8.3"
+                    - "8.4"
                 operating-system:
                     - "ubuntu-latest"
 
         steps:
             - name: "checkout"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
 
             - name: "installing PHP"
               uses: "shivammathur/setup-php@v2"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ of the Composer documentation.
 Open a command console, enter your project directory and execute:
 
 ```console
-$ composer require dunglas/digital-ocean-bundle symfony/http-client nyholm/psr7 guzzlehttp/promises
+composer require dunglas/digital-ocean-bundle symfony/http-client nyholm/psr7 guzzlehttp/promises
 ```
 
 The previous command installs the bundle, Symfony HttpClient and [the dependencies it needs](https://symfony.com.ua/doc/current/http_client.html#psr-18-and-psr-17)

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,20 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/config": "^4.4 || ^5.4 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "symfony/config": "^4.4 || ^5.4 || ^6.4 || ^7.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.4 || ^7.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.4 || ^7.0",
         "toin0u/digitalocean-v2": "^4.3"
     },
     "require-dev": {
         "guzzlehttp/promises": "^1.4",
         "nyholm/psr7": "^1.4",
-        "symfony/http-client": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-client": "^4.4 || ^5.4 || ^6.4 || ^7.0",
         "symfony/phpunit-bridge": "^6.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "symfony/config": "^4.4 || ^5.4 || ^6.4 || ^7.0",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.4 || ^7.0",
         "symfony/http-kernel": "^4.4 || ^5.4 || ^6.4 || ^7.0",
@@ -29,7 +29,7 @@
         "guzzlehttp/promises": "^1.4 || ^2.0",
         "nyholm/psr7": "^1.4",
         "symfony/http-client": "^4.4 || ^5.4 || ^6.4 || ^7.0",
-        "symfony/phpunit-bridge": "^6.4 || ^7.0"
+        "symfony/phpunit-bridge": "^7.2.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         "toin0u/digitalocean-v2": "^4.3"
     },
     "require-dev": {
-        "guzzlehttp/promises": "^1.4",
+        "guzzlehttp/promises": "^1.4 || ^2.0",
         "nyholm/psr7": "^1.4",
         "symfony/http-client": "^4.4 || ^5.4 || ^6.4 || ^7.0",
-        "symfony/phpunit-bridge": "^6.0"
+        "symfony/phpunit-bridge": "^6.4 || ^7.0"
     },
     "config": {
         "allow-plugins": {

--- a/src/DependencyInjection/DunglasDigitalOceanExtension.php
+++ b/src/DependencyInjection/DunglasDigitalOceanExtension.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
  */
 final class DunglasDigitalOceanExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 


### PR DESCRIPTION
Fixes #4 , simple-phpunit tests pass.  I added the void return type, but I'm not sure if that will cause a problem with older versions of php.